### PR TITLE
profile: Add new profile page for the Hedgehog organisation

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -1,0 +1,45 @@
+## We're Hedgehog! :hedgehog: :wave:
+
+And we're working on the Open Network Fabric, to bring users the power and
+experience from public cloud providers to their private environments. Welcome!
+
+### The Open Network Fabric
+
+The Hedgehog Open Network Fabric is an open networking platform that leverages
+the [SONiC network operating system][sonic], provides network connectivity,
+tooling, and automation to deploy scalable cloud infrastructure on your
+commodity hardware, without vendor lock-in.
+
+The Open Network Fabric is built around the concept of VPCs (Virtual Private
+Clouds), similar to public cloud offerings. It provides a multi-tenant API to
+define the user intent on network isolation and connectivity, which is
+automatically transformed into configuration for switches and software
+appliances. Built on top of Kubernetes, the project uses Kubernetes API to
+manage its resources, meaning that all user-facing APIs are Kubernetes Custom
+Resources (CRDs), so you can use standard Kubernetes tools to manage resources
+in the fabric.
+
+<img src="https://githedgehog.com/hubfs/Concepts/hero-hedgehog-is-the-ai-network.svg"
+  alt="Hedgehog Open Network Fabric illustration" width="500" />
+
+The Open Network Fabric is an open-source project, and you're welcome to
+contribute!
+
+For more information about the Open Network Fabric, take a look at [the
+documentation][docs].
+
+[docs]: https://docs.githedgehog.com
+[sonic]: https://sonicfoundation.dev/
+
+### Hedgehog
+
+Hedgehog is the company behind the Open Networking Fabric. For more information
+about us, consult [our website][hedgehog] or take a look at [our blog][blog].
+You can also follow us on [Twitter/X][x], [LinkedIn][linkedin], or
+[YouTube][youtube].
+
+[hedgehog]: https://hedgehog.cloud
+[blog]: https://hedgehog.cloud/blog
+[x]: https://x.com/githedgehog
+[linkedin]: https://www.linkedin.com/company/githedgehog
+[youtube]: https://www.youtube.com/@hedgehog-sonic


### PR DESCRIPTION
Add a new README.md to display information about Hedgehog and the Fabric on the public GitHub profile page for Hedgehog.
